### PR TITLE
feat: create organization + dev user and prod access role

### DIFF
--- a/env/general/organization/terragrunt.hcl
+++ b/env/general/organization/terragrunt.hcl
@@ -1,0 +1,11 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../lab//organization"
+}
+inputs = {
+  account_name  = "associate-dev"
+  account_email = "unique-email@some-domain.com"
+}

--- a/env/prod/organization-account-access-role/terragrunt.hcl
+++ b/env/prod/organization-account-access-role/terragrunt.hcl
@@ -1,0 +1,10 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../lab//organization-account-access-role"
+}
+inputs = {
+  account_id = "1234567890" # Set to your `general` account ID
+}

--- a/lab/organization-account-access-role/main.tf
+++ b/lab/organization-account-access-role/main.tf
@@ -1,0 +1,23 @@
+# You must manually invite the `prod` iamadmin user to the organization for this
+# to work.  This is a bit odd - in a normal situation, the prod account would be
+# managed along with the organization via Terraform.
+
+resource "aws_iam_role" "assume_role" {
+  name = "OrganizationAccountAccessRole"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : {
+      "Effect" : "Allow",
+      "Principal" : {
+        "AWS" : "arn:aws:iam::${var.account_id}:root"
+      },
+      "Action" : "sts:AssumeRole"
+    }
+  })
+}
+
+# Grant the assumed role a managed policy (defaults to AdministratorAccess for the lab)
+resource "aws_iam_role_policy_attachment" "default" {
+  role       = aws_iam_role.assume_role.name
+  policy_arn = var.policy_arn
+}

--- a/lab/organization-account-access-role/variables.tf
+++ b/lab/organization-account-access-role/variables.tf
@@ -1,0 +1,10 @@
+variable "account_id" {
+  description = "ID of the account to grant full access to"
+  type        = string
+}
+
+variable "policy_arn" {
+  description = "Managed policy ARN to attach"
+  type        = string
+  default     = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/lab/organization/main.tf
+++ b/lab/organization/main.tf
@@ -1,0 +1,10 @@
+resource "aws_organizations_organization" "this" {
+
+}
+
+# This will fail until you validate your organizations management account's email address
+# In this case, the management account will be the `general` iamadmin
+resource "aws_organizations_account" "this" {
+  name  = var.account_name
+  email = var.account_email
+}

--- a/lab/organization/variables.tf
+++ b/lab/organization/variables.tf
@@ -1,0 +1,7 @@
+variable "account_name" {
+  type = string
+}
+
+variable "account_email" {
+  type = string
+}


### PR DESCRIPTION
Allows the `general` user to assume dev and prod admin access

Closes #10 