### PR TITLE
fix: Lambda timeouts to EC2 fixed by allowing public AWS egress

### DIFF
--- a/env/general/lambda-ec2/terragrunt.hcl
+++ b/env/general/lambda-ec2/terragrunt.hcl
@@ -33,8 +33,7 @@ terraform {
 }
 inputs = {
   lambda_functions = ["start", "stop"]
-  subnets_lambda   = ["sn-web-A", "sn-web-B", "sn-web-C"]
+  subnets_lambda   = ["sn-app-A","sn-app-B","sn-app-C"]
   subnets          = dependency.network.outputs.subnets
   vpc_id           = dependency.network.outputs.vpc_id
-  vpc_cidr_block   = "10.16.0.0/16"
 }

--- a/lab/lambda-ec2/lambda.tf
+++ b/lab/lambda-ec2/lambda.tf
@@ -28,10 +28,10 @@ resource "aws_lambda_function" "functions" {
   handler          = "${each.key}.lambda_handler"
   runtime          = "python3.8"
 
-  timeout = 20
+  timeout = 5
 
   vpc_config {
-    security_group_ids = [aws_security_group.allow_lambda_on_vpc.id]
+    security_group_ids = [aws_security_group.allow_lambda_egress.id]
     subnet_ids         = local.subnet_ids
   }
 
@@ -41,20 +41,16 @@ resource "aws_lambda_function" "functions" {
   ]
 }
 
-resource "aws_security_group" "allow_lambda_on_vpc" {
-  name        = "allow_lambda_on_vpc"
-  description = "Allow Lambda function to communicate with the VPC resources"
+resource "aws_security_group" "allow_lambda_egress" {
+  name        = "allow_lambda_egress"
+  description = "Allow Lambda function to communicate with public AWS"
   vpc_id      = var.vpc_id
 
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = [var.vpc_cidr_block]
-  }
-
-  tags = {
-    Name = "allow_lambda_on_vpc"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS009
   }
 }
 

--- a/lab/lambda-ec2/variables.tf
+++ b/lab/lambda-ec2/variables.tf
@@ -22,8 +22,3 @@ variable "vpc_id" {
   description = "VPC of the subnets the Lambda function will be attached to"
   type        = string
 }
-
-variable "vpc_cidr_block" {
-  description = "IPv4 cidr block of the VPC"
-  type        = string
-}


### PR DESCRIPTION
The function communicates through the NAT to IGW to public AWS services
to invoke the EC2 stop action.

Closes #58 