### PR TITLE
feat: Lambda interacting with EC2 using VPC Endpoint (Interface)

### DIFF
--- a/env/general/lambda-ec2-vpc-endpoint/terragrunt.hcl
+++ b/env/general/lambda-ec2-vpc-endpoint/terragrunt.hcl
@@ -1,0 +1,10 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../lab//lambda-ec2-vpc-endpoint"
+}
+inputs = {
+  lambda_functions = ["start", "stop"]
+}

--- a/lab/lambda-ec2-vpc-endpoint/functions/start.py
+++ b/lab/lambda-ec2-vpc-endpoint/functions/start.py
@@ -1,0 +1,14 @@
+import boto3
+import os
+import json
+
+region = 'us-east-1'
+ec2 = boto3.client('ec2', region_name=region)
+
+def lambda_handler(event, context):
+    print("Received event: " + json.dumps(event))
+    instance=[ event["detail"]["instance-id"] ]    
+
+    print("Starting " + str(instance))
+    ec2.start_instances(InstanceIds=instance)
+    print("Started instance: " + str(instance))

--- a/lab/lambda-ec2-vpc-endpoint/functions/stop.py
+++ b/lab/lambda-ec2-vpc-endpoint/functions/stop.py
@@ -1,0 +1,14 @@
+import boto3
+import os
+import json
+
+region = "us-east-1"
+ec2 = boto3.client("ec2", region_name=region)
+
+def lambda_handler(event, context):
+    print("Received event: " + json.dumps(event))
+    instance=[ event["detail"]["instance-id"] ]    
+
+    print("Stopping " + str(instance))
+    ec2.stop_instances(InstanceIds=instance)
+    print("Stopped instance: " + str(instance))

--- a/lab/lambda-ec2-vpc-endpoint/instance.tf
+++ b/lab/lambda-ec2-vpc-endpoint/instance.tf
@@ -1,0 +1,25 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "instance_stop_start" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+  subnet_id     = aws_subnet.subnet_test.id
+
+  tags = {
+    Name = "StopStarter"
+  }
+}

--- a/lab/lambda-ec2-vpc-endpoint/instance.tf
+++ b/lab/lambda-ec2-vpc-endpoint/instance.tf
@@ -19,6 +19,10 @@ resource "aws_instance" "instance_stop_start" {
   instance_type = "t3.micro"
   subnet_id     = aws_subnet.subnet_test.id
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags = {
     Name = "StopStarter"
   }

--- a/lab/lambda-ec2-vpc-endpoint/lambda.tf
+++ b/lab/lambda-ec2-vpc-endpoint/lambda.tf
@@ -32,22 +32,8 @@ resource "aws_lambda_function" "functions" {
 
 resource "aws_security_group" "allow_lambda_egress" {
   name        = "allow_lambda_egress"
-  description = "Allow Lambda function to communicate with AWS services"
+  description = "Allow Lambda function to communicate with AWS service endpoints"
   vpc_id      = aws_vpc.vpc_test.id
-
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "TCP"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # egress {
-  #   from_port       = 443
-  #   to_port         = 443
-  #   protocol        = "TCP"
-  #   prefix_list_ids = aws_vpc_endpoint.cloudwatch_endpoint.network_interface_ids
-  # }
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {

--- a/lab/lambda-ec2-vpc-endpoint/lambda.tf
+++ b/lab/lambda-ec2-vpc-endpoint/lambda.tf
@@ -1,0 +1,123 @@
+data "archive_file" "lambda_functions" {
+  for_each = var.lambda_functions
+
+  type        = "zip"
+  source_file = "functions/${each.key}.py"
+  output_path = "functions/${each.key}.zip"
+}
+
+resource "aws_lambda_function" "functions" {
+  for_each = var.lambda_functions
+
+  function_name = "${each.key}-${var.env}"
+  role          = aws_iam_role.lambda_role.arn
+
+  filename         = "functions/${each.key}.zip"
+  source_code_hash = data.archive_file.lambda_functions[each.key].output_base64sha256
+  handler          = "${each.key}.lambda_handler"
+  runtime          = "python3.8"
+
+  timeout = 5
+
+  vpc_config {
+    security_group_ids = [aws_security_group.allow_lambda_egress.id]
+    subnet_ids         = [aws_subnet.subnet_test.id]
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.lambda_policy_attachment,
+    aws_cloudwatch_log_group.lambda_log_group,
+  ]
+}
+
+resource "aws_security_group" "allow_lambda_egress" {
+  name        = "allow_lambda_egress"
+  description = "Allow Lambda function to communicate with AWS services"
+  vpc_id      = aws_vpc.vpc_test.id
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # egress {
+  #   from_port       = 443
+  #   to_port         = 443
+  #   protocol        = "TCP"
+  #   prefix_list_ids = aws_vpc_endpoint.cloudwatch_endpoint.network_interface_ids
+  # }
+}
+
+resource "aws_cloudwatch_log_group" "lambda_log_group" {
+  name              = "/aws/lambda"
+  retention_in_days = 14
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name = "lambda_role"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : "sts:AssumeRole",
+        "Principal" : {
+          "Service" : "lambda.amazonaws.com"
+        },
+        "Effect" : "Allow",
+        "Sid" : ""
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "lambda_policy" {
+  name        = "lambda_ec2_logging"
+  path        = "/"
+  description = "IAM policy for interacting with EC2 and CloudWatch"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        "Resource" : "arn:aws:logs:*:*:*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:Start*",
+          "ec2:Stop*",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:CreateNetworkInterface",
+          "ec2:DeleteNetworkInterface",
+          "ec2:AttachNetworkInterface"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.lambda_policy.arn
+}
+
+
+# Example of using a null_resource debug variables
+# resource "null_resource" "debug_subnet_ids" {
+#   provisioner "local-exec" {
+#     command = "echo ${join(",", local.subnet_ids)}"
+#   }
+#   triggers = {
+#     always_run = "${timestamp()}"
+#   }
+# }

--- a/lab/lambda-ec2-vpc-endpoint/lambda.tf
+++ b/lab/lambda-ec2-vpc-endpoint/lambda.tf
@@ -30,10 +30,20 @@ resource "aws_lambda_function" "functions" {
   ]
 }
 
+# Allow the Lambda functions to communicate with resources in the VPC.  This is required
+# since the VPC Endpoint (Interface) deploys an ENI in the VPC that the functions need
+# to talk to.
 resource "aws_security_group" "allow_lambda_egress" {
   name        = "allow_lambda_egress"
   description = "Allow Lambda function to communicate with AWS service endpoints"
   vpc_id      = aws_vpc.vpc_test.id
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = [aws_vpc.vpc_test.cidr_block]
+  }
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
@@ -96,14 +106,3 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = aws_iam_policy.lambda_policy.arn
 }
-
-
-# Example of using a null_resource debug variables
-# resource "null_resource" "debug_subnet_ids" {
-#   provisioner "local-exec" {
-#     command = "echo ${join(",", local.subnet_ids)}"
-#   }
-#   triggers = {
-#     always_run = "${timestamp()}"
-#   }
-# }

--- a/lab/lambda-ec2-vpc-endpoint/network.tf
+++ b/lab/lambda-ec2-vpc-endpoint/network.tf
@@ -1,0 +1,48 @@
+data "aws_region" "current" {}
+
+locals {
+  region = data.aws_region.current.name
+}
+
+resource "aws_vpc" "vpc_test" {
+  cidr_block           = "10.16.0.0/16"
+  instance_tenancy     = "default"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "subnet_test" {
+  vpc_id            = aws_vpc.vpc_test.id
+  cidr_block        = "10.16.0.0/20"
+  availability_zone = "${local.region}a"
+}
+
+resource "aws_vpc_endpoint" "ec2_endpoint" {
+  vpc_id            = aws_vpc.vpc_test.id
+  service_name      = "com.amazonaws.${local.region}.ec2"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.privatelink.id,
+  ]
+
+  subnet_ids = [aws_subnet.subnet_test.id]
+}
+
+resource "aws_vpc_endpoint" "cloudwatch_endpoint" {
+  vpc_id            = aws_vpc.vpc_test.id
+  service_name      = "com.amazonaws.${local.region}.logs"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.privatelink.id,
+  ]
+
+  subnet_ids = [aws_subnet.subnet_test.id]
+}
+
+resource "aws_security_group" "privatelink" {
+  name        = "PrivateLink"
+  description = "PrivateLink endpoints"
+  vpc_id      = aws_vpc.vpc_test.id
+}

--- a/lab/lambda-ec2-vpc-endpoint/network.tf
+++ b/lab/lambda-ec2-vpc-endpoint/network.tf
@@ -43,6 +43,7 @@ resource "aws_vpc_endpoint" "cloudwatch_endpoint" {
   private_dns_enabled = true
 }
 
+# Allow communication from the Lambda SG
 resource "aws_security_group" "vpc_endpoint" {
   name        = "vpc_endpoint"
   description = "Allow TCP 443 over PrivateLink for AWS service endpoints"

--- a/lab/lambda-ec2-vpc-endpoint/network.tf
+++ b/lab/lambda-ec2-vpc-endpoint/network.tf
@@ -23,10 +23,11 @@ resource "aws_vpc_endpoint" "ec2_endpoint" {
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
-    aws_security_group.privatelink.id,
+    aws_security_group.vpc_endpoint.id,
   ]
 
-  subnet_ids = [aws_subnet.subnet_test.id]
+  subnet_ids          = [aws_subnet.subnet_test.id]
+  private_dns_enabled = true
 }
 
 resource "aws_vpc_endpoint" "cloudwatch_endpoint" {
@@ -35,14 +36,22 @@ resource "aws_vpc_endpoint" "cloudwatch_endpoint" {
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
-    aws_security_group.privatelink.id,
+    aws_security_group.vpc_endpoint.id,
   ]
 
-  subnet_ids = [aws_subnet.subnet_test.id]
+  subnet_ids          = [aws_subnet.subnet_test.id]
+  private_dns_enabled = true
 }
 
-resource "aws_security_group" "privatelink" {
-  name        = "PrivateLink"
-  description = "PrivateLink endpoints"
+resource "aws_security_group" "vpc_endpoint" {
+  name        = "vpc_endpoint"
+  description = "Allow TCP 443 over PrivateLink for AWS service endpoints"
   vpc_id      = aws_vpc.vpc_test.id
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "TCP"
+    security_groups = [aws_security_group.allow_lambda_egress.id]
+  }
 }

--- a/lab/lambda-ec2-vpc-endpoint/outputs.tf
+++ b/lab/lambda-ec2-vpc-endpoint/outputs.tf
@@ -1,0 +1,9 @@
+output "invoke_arn" {
+  value = {
+    for function_key, function in aws_lambda_function.functions :
+    function_key => ({
+      "function_name" = function.function_name
+      "invoke_arn"    = function.invoke_arn
+    })
+  }
+}

--- a/lab/lambda-ec2-vpc-endpoint/variables.tf
+++ b/lab/lambda-ec2-vpc-endpoint/variables.tf
@@ -1,0 +1,9 @@
+variable "env" {
+  description = "Name of the environment we're working in."
+  type        = string
+}
+
+variable "lambda_functions" {
+  description = "Names of the lambda functions that will be created.  There must be a matching <name>.py in the lab's functions directory."
+  type        = set(string)
+}


### PR DESCRIPTION
Example of how Lambda function can use a VPC Endpoint to interact with public AWS services instead of a NAT and IGW.

Closes #62 